### PR TITLE
Add contents:write permission to GitHub token

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -14,7 +14,7 @@ jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
 
     steps:


### PR DESCRIPTION
The create-release action was failing because
it needs to write content to the repository.