### PR TITLE
Use a more explicit version for base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.10.1-alpine3.15
 
 # hadolint ignore=DL3013,DL3018
 RUN pip install --no-cache-dir truffleHog && \


### PR DESCRIPTION
Hopefully this will allow dependabot to help me
with keeping dependencies up to date.
Also, explicit is better than implicit :D