### PR TITLE
Use requirements.txt to track TruffleHog versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,10 @@ updates:
       interval: "daily"
     reviewers:
       - "channelbeta"
+  # Maintain dependencies for TruffleHog/Python
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "channelbeta"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM python:3.10.3-alpine3.15
 
-# hadolint ignore=DL3013,DL3018
-RUN pip install --no-cache-dir truffleHog && \
-    apk add --no-cache git less openssh
+# hadolint ignore=DL3018
+RUN apk add --no-cache git less openssh
+
+COPY "requirements.txt" "/requirements.txt"
+RUN pip install --no-cache-dir --requirement requirements.txt
 
 COPY "entrypoint.sh" "/entrypoint.sh"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+truffleHog==2.2.1
+truffleHogRegexes==0.0.7


### PR DESCRIPTION
Thus making it easier to keep it up to date with Dependabot